### PR TITLE
Avoid self replies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+# Issue
+
+<_Issue link_>
+
+# What has changed?
+
+<_Brief explanation of what this PR adds_>
+
+# How to test
+
+<_Testing information_>

--- a/lib/spotify_uri_bot/bot.ex
+++ b/lib/spotify_uri_bot/bot.ex
@@ -10,6 +10,7 @@ defmodule SpotifyUriBot.Bot do
 
   middleware(SpotifyUriBot.Middleware.Stats)
   middleware(SpotifyUriBot.Middleware.Admin)
+  middleware(SpotifyUriBot.Middleware.IgnoreBotMessage)
 
   def bot(), do: @bot
 
@@ -26,7 +27,10 @@ defmodule SpotifyUriBot.Bot do
     end
   end
 
-  def handle({:text, text, %{message_id: message_id}}, context) do
+  def handle(
+        {:text, text, %{message_id: message_id}},
+        %{extra: %{message_from_bot: false}} = context
+      ) do
     case get_entity(text) do
       {:ok, _, result} ->
         {message, markup} = MessageFormatter.get_message_with_markup(result)

--- a/lib/spotify_uri_bot/bot.ex
+++ b/lib/spotify_uri_bot/bot.ex
@@ -27,10 +27,7 @@ defmodule SpotifyUriBot.Bot do
     end
   end
 
-  def handle(
-        {:text, text, %{message_id: message_id}},
-        %{extra: %{message_from_bot: false}} = context
-      ) do
+  def handle({:text, text, %{message_id: message_id}}, context) do
     case get_entity(text) do
       {:ok, _, result} ->
         {message, markup} = MessageFormatter.get_message_with_markup(result)

--- a/lib/spotify_uri_bot/middleware/ignore_bot_message.ex
+++ b/lib/spotify_uri_bot/middleware/ignore_bot_message.ex
@@ -1,0 +1,15 @@
+defmodule SpotifyUriBot.Middleware.IgnoreBotMessage do
+  use ExGram.Middleware
+
+  alias ExGram.Cnt
+
+  def call(%Cnt{update: %{message: %{text: text}}} = cnt, _opts) do
+    if String.contains?(text, "🔗 URI: ") do
+      add_extra(cnt, :message_from_bot, true)
+    else
+      add_extra(cnt, :message_from_bot, false)
+    end
+  end
+
+  def call(cnt, _), do: cnt
+end

--- a/lib/spotify_uri_bot/middleware/ignore_bot_message.ex
+++ b/lib/spotify_uri_bot/middleware/ignore_bot_message.ex
@@ -3,11 +3,23 @@ defmodule SpotifyUriBot.Middleware.IgnoreBotMessage do
 
   alias ExGram.Cnt
 
-  def call(%Cnt{update: %{message: %{text: text}}} = cnt, _opts) do
-    if String.contains?(text, "🔗 URI: ") do
-      add_extra(cnt, :message_from_bot, true)
+  defp is_spotify_button?(%{text: "Open in Spotify"}), do: true
+  defp is_spotify_button?(_), do: false
+
+  def call(
+        %Cnt{
+          update: %{
+            message: %{
+              reply_markup: %{inline_keyboard: [[first_button | _] | _]}
+            }
+          }
+        } = cnt,
+        _opts
+      ) do
+    if is_spotify_button?(first_button) do
+      %{cnt | halted: true}
     else
-      add_extra(cnt, :message_from_bot, false)
+      cnt
     end
   end
 


### PR DESCRIPTION
**Issue**

#5 

**What has changed?**

This PR adds a middleware called `SpotifyUriBot.Middleware.IgnoreBotMessage` that will check if a message comes with the `Open in Spotify` inline button and consider that a bot message and will not reply to that.

**How to test**

- Send an uri `spotify:track:6ZsZxNP4Iwdyp3kd5oFFQN` to the bot via message (_not inline_)
  + _The bot should reply_
- Send a result message via inline typing `@test_bot spotify:track:6ZsZxNP4Iwdyp3kd5oFFQN` and clicking in a result
  + _The bot should NOT reply to that message_