### PR TITLE
Fix no audio_file_id

### DIFF
--- a/lib/spotify_uri_bot/message_formatter.ex
+++ b/lib/spotify_uri_bot/message_formatter.ex
@@ -70,7 +70,8 @@ defmodule SpotifyUriBot.MessageFormatter do
 
   def get_inline_article(entity, opts \\ [])
 
-  def get_inline_article(%{preview_url: _preview_url} = entity, opts) do
+  def get_inline_article(%{preview_url: preview_url} = entity, opts)
+      when not is_nil(preview_url) do
     {message_text, markup} = get_message_with_markup(entity)
 
     %InlineQueryResultAudio{


### PR DESCRIPTION
# Issue

#18 

# What has changed?

This PR fixes the `can't find field \"audio_file_id\"` error

# How to test

Search with this inline query:
`@spotify_uri_bot spotify:artist:1w5Kfo2jwwIPruYS2UWh56`

The result should have some songs with previews, _not all_
